### PR TITLE
get flood mask built based on the original flood hazard layer (prior …

### DIFF
--- a/R/configure-earthquake.R
+++ b/R/configure-earthquake.R
@@ -37,16 +37,16 @@ if(!file.exists(hazard_path_out) | overwrite) {
            t_srs = crs(empty_grid), 
            tr = c(250, 250), 
            overwrite = TRUE,
-           s_srs = "EPSG:4326")
+           s_srs = "EPSG:4326",
+           r = "bilinear")
   
-  gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
+  hazard <- gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
                            reference = empty_grid@file@name, 
                            dstfile = hazard_path_out, 
-                           overwrite = TRUE)
+                           overwrite = TRUE,
+                           output_Raster = TRUE)
   
   unlink(hazard_path_tmp)
-  
-  hazard <- raster::raster(hazard_path_out)
   
   # Mask out the pixels outside of CONUS using the water mask derived from the 
   # USAboundaries package high resolution CONUS shapefile (rasterized to the Zillow

--- a/R/configure-fire.R
+++ b/R/configure-fire.R
@@ -39,19 +39,19 @@ if(!file.exists(hazard_path_out) | overwrite) {
            dstfile = hazard_path_tmp, 
            t_srs = crs(empty_grid), 
            tr = c(250, 250), 
-           overwrite = TRUE)
+           overwrite = TRUE,
+           r = "bilinear")
   
   unlink(paste0(hazard_path_tmp, ".aux.xml"))
 
-  gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
+  hazard <- gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
                            reference = empty_grid@file@name, 
                            dstfile = hazard_path_out, 
-                           overwrite = TRUE)
+                           overwrite = TRUE,
+                           output_Raster = TRUE)
   
   unlink(hazard_path_tmp)
-  
-  hazard <- raster::raster(hazard_path_out)
-  
+
   # Mask out the pixels outside of CONUS using the water mask derived from the 
   # USAboundaries package high resolution CONUS shapefile (rasterized to the Zillow
   # grid) and the flood hazard layer, with all values of 999 masked out (representing

--- a/R/configure-hurricane-stormsurge.R
+++ b/R/configure-hurricane-stormsurge.R
@@ -7,6 +7,9 @@ library(raster)
 library(fasterize)
 library(lubridate)
 library(tidyverse)
+# devtools::install_github(repo = "JoshOBrien/rasterDT")
+library(rasterDT)
+library(gdalUtils)
 
 source("R/download_grid.R")
 source("R/download_hazard.R")
@@ -38,25 +41,25 @@ if(!file.exists(hazard_path_out) | overwrite) {
   
   hazard_orig <- raster::raster(hazard_path_src)
   
-  gdalwarp(srcfile = hazard_path_src, 
-           dstfile = hazard_path_tmp, 
-           t_srs = crs(empty_grid), 
-           tr = c(250, 250), 
-           overwrite = TRUE,
-           s_srs = crs(hazard_orig))
+  gdalUtils::gdalwarp(srcfile = hazard_path_src, 
+                      dstfile = hazard_path_tmp, 
+                      t_srs = crs(empty_grid), 
+                      tr = c(250, 250), 
+                      overwrite = TRUE,
+                      s_srs = crs(hazard_orig),
+                      r = "bilinear")
   
-  gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
-                           reference = empty_grid@file@name, 
-                           dstfile = hazard_path_out, 
-                           overwrite = TRUE)
+  hazard <- gdalUtils::align_rasters(unaligned = hazard_path_tmp, 
+                                     reference = empty_grid@file@name, 
+                                     dstfile = hazard_path_out, 
+                                     overwrite = TRUE,
+                                     output_Raster = TRUE)
   
   unlink(hazard_path_tmp)
   
-  # Read the hazard layer using the raster package so we can mask it
+  # Make 0/NA handling consistent by using a 0 within CONUS for "no hazard"
   hazard <- 
-    raster::raster(hazard_path_out) %>% 
-    # Make 0/NA handling consistent by using a 0 within CONUS for "no hazard"
-    raster::reclassify(rcl = cbind(NA, 0))
+    rasterDT::subsDT(x = hazard, dict = data.table(by = NA, which = 0), subsWithNA = FALSE)
   
   # Mask out the pixels outside of CONUS using the water mask derived from the 
   # USAboundaries package high resolution CONUS shapefile (rasterized to the Zillow

--- a/R/configure-tornado.R
+++ b/R/configure-tornado.R
@@ -19,73 +19,87 @@ if(!dir.exists(file.path("output", "hazards"))) {
 
 hazard_name <- "tornado"
 hazard_path_out <- file.path("output", "hazards", paste0(hazard_name, "_zillow-grid.tif"))
+hazard_path_unmasked <- file.path("data", "hazards", hazard_name, paste0(hazard_name, "_unmasked.tif"))
+
+if(!dir.exists(file.path("data", "hazards", hazard_name))) {
+  dir.create(file.path("data", "hazards", hazard_name), recursive = TRUE)
+}
 
 overwrite <- FALSE
 
 if(!file.exists(hazard_path_out) | overwrite) {
-
-  conus <- 
-    USAboundaries::us_boundaries(type = "state", resolution = "high") %>%
-    filter(!state_name %in% c("Alaska", "Hawaii") & jurisdiction_type == "state") %>%
-    st_transform(projection(empty_grid))
+  if(!file.exists(hazard_path_unmasked) | overwrite) {
+    conus <- 
+      USAboundaries::us_boundaries(type = "state", resolution = "high") %>%
+      filter(!state_name %in% c("Alaska", "Hawaii") & jurisdiction_type == "state") %>%
+      st_transform(projection(empty_grid))
+    
+    # Get the tornado data
+    tornado_paths <- tornadoes() %>%
+      as('sf') %>%
+      st_transform(crs = projection(empty_grid))
+    
+    # subset to a particular time interval
+    # 1982 is when F-scale rating were consistently recorded
+    max_year <- 2018
+    min_year <- 1982
+    n_year <- length(min_year:max_year)
+    tornado_paths <- tornado_paths %>%
+      filter(yr >= min_year, 
+             yr <= max_year)
+    
+    # buffer at 300 m
+    # https://journals.ametsoc.org/doi/pdf/10.1175/JAMC-D-13-0235.1
+    buffered_paths <- st_buffer(tornado_paths, dist = 300)
+    
+    # Compute an annual empirical frequency for each grid cell
+    # (# years with events / total # years)
+    # and save to a tif file
+    tornado_counts <- buffered_paths %>%
+      group_by(yr) %>%
+      summarize %>% 
+      st_cast("MULTIPOLYGON") %>%
+      fasterize(raster = empty_grid, fun = 'sum', background = 0)
+    
+    
+    tornado_freq <- tornado_counts / n_year
+    plot(tornado_freq)
+    
+    # Smoothing
+    gf <- focalWeight(tornado_freq, 10000, "circle")
+    vx <- velox::velox(x = tornado_freq)
+    
+    # meanFocal operation takes about 38 minutes on the Alienware. 
+    # Velox should be quite a bit faster than the raster::focal()
+    # implementation. See http://philipphunziker.com/velox/benchmark.html
+    vx$meanFocal(weights = gf)
+    rg <- vx$as.RasterLayer()
+    
+    plot(rg, col = viridis::viridis(100))
+    
+    rg_01 <- rg / cellStats(rg, stat = "sum")
+    rg_scaled <- rg_01 * cellStats(tornado_freq, stat = "sum")
+    
+    cellStats(tornado_freq, stat = "sum")
+    cellStats(rg_scaled, stat = "sum")
+    
+    raster::writeRaster(x = rg_scaled, filename = hazard_path_unmasked)
+  }
   
-  # Get the tornado data
-  tornado_paths <- tornadoes() %>%
-    as('sf') %>%
-    st_transform(crs = projection(empty_grid))
-  
-  # subset to a particular time interval
-  # 1982 is when F-scale rating were consistently recorded
-  max_year <- 2018
-  min_year <- 1982
-  n_year <- length(min_year:max_year)
-  tornado_paths <- tornado_paths %>%
-    filter(yr >= min_year, 
-           yr <= max_year)
-  
-  # buffer at 300 m
-  # https://journals.ametsoc.org/doi/pdf/10.1175/JAMC-D-13-0235.1
-  buffered_paths <- st_buffer(tornado_paths, dist = 300)
-  
-  # Compute an annual empirical frequency for each grid cell
-  # (# years with events / total # years)
-  # and save to a tif file
-  tornado_counts <- buffered_paths %>%
-    group_by(yr) %>%
-    summarize %>% 
-    st_cast("MULTIPOLYGON") %>%
-    fasterize(raster = empty_grid, fun = 'sum', background = 0)
-  
-  
-  tornado_freq <- tornado_counts / n_year
-  plot(tornado_freq)
-  
-  # Smoothing
-  gf <- focalWeight(tornado_freq, 10000, "circle")
-  vx <- velox::velox(x = tornado_freq)
-  
-  # meanFocal operation takes about 38 minutes on the Alienware. 
-  # Velox should be quite a bit faster than the raster::focal()
-  # implementation. See http://philipphunziker.com/velox/benchmark.html
-  vx$meanFocal(weights = gf)
-  rg <- vx$as.RasterLayer()
-  
-  plot(rg, col = viridis::viridis(100))
-  
-  rg_01 <- rg / cellStats(rg, stat = "sum")
-  rg_scaled <- rg_01 * cellStats(tornado_freq, stat = "sum")
-  
-  cellStats(tornado_freq, stat = "sum")
-  cellStats(rg_scaled, stat = "sum")
+  hazard <- raster::raster(hazard_path_unmasked)
   
   # Mask out the pixels outside of CONUS using the water mask derived from the 
   # USAboundaries package high resolution CONUS shapefile (rasterized to the Zillow
   # grid) and the flood hazard layer, with all values of 999 masked out (representing
   # persistent water bodies)
-  mask <- raster::raster("output/water-mask_zillow-grid.tif")
-  rg_scaled <- raster::mask(x = rg_scaled, mask = mask)
+  if(!file.exists(file.path("output", "water-mask_zillow-grid.tif"))) {
+    source("R/configure-flood.R")
+  }
   
-  writeRaster(x = rg_scaled, 
+  mask <- raster::raster("output/water-mask_zillow-grid.tif")
+  hazard <- raster::mask(x = hazard, mask = mask)
+  
+  writeRaster(x = hazard, 
               filename = hazard_path_out, 
               overwrite = TRUE)
 }


### PR DESCRIPTION
…to warping), which lets us use bilinear interpolation the rest of the way (because the nodata category, which is equal to 999 in the flood layer) won't get averaged across nearby pixels first. They'll be appropriately turned to masked values and then that mask will propagate along up the aggregation levels when warping occurs.